### PR TITLE
Allow to specify the environment variables for the process

### DIFF
--- a/lib/analysis_server_lib.dart
+++ b/lib/analysis_server_lib.dart
@@ -61,7 +61,8 @@ class AnalysisServer {
       List<String> vmArgs,
       List<String> serverArgs,
       String clientId,
-      String clientVersion}) async {
+      String clientVersion,
+      Map<String, String> processEnvironment}) async {
     Completer<int> processCompleter = new Completer();
 
     String vmPath;
@@ -80,7 +81,8 @@ class AnalysisServer {
     if (clientId != null) args.add('--client-id=$clientId');
     if (clientVersion != null) args.add('--client-version=$clientVersion');
 
-    Process process = await Process.start(vmPath, args);
+    Process process =
+        await Process.start(vmPath, args, environment: processEnvironment);
     process.exitCode.then((code) => processCompleter.complete(code));
 
     Stream<String> inStream = process.stdout

--- a/tool/generate_analysis.dart
+++ b/tool/generate_analysis.dart
@@ -1037,7 +1037,8 @@ final String _staticFactory = r'''
   static Future<AnalysisServer> create(
       {String sdkPath, String scriptPath, onRead(String), onWrite(String),
        List<String> vmArgs, List<String> serverArgs,
-       String clientId, String clientVersion}) async {
+       String clientId, String clientVersion,
+      Map<String, String> processEnvironment}) async {
     Completer<int> processCompleter = new Completer();
 
     String vmPath;
@@ -1055,7 +1056,7 @@ final String _staticFactory = r'''
     if (clientId != null) args.add('--client-id=$clientId');
     if (clientVersion != null) args.add('--client-version=$clientVersion');
 
-    Process process = await Process.start(vmPath, args);
+    Process process = await Process.start(vmPath, args, environment: processEnvironment);
     process.exitCode.then((code) => processCompleter.complete(code));
 
     Stream<String> inStream = process.stdout


### PR DESCRIPTION
This allows to pass the variable `HOME` or  `APPLOCALDATA` to control where the analysis-server should put the temporary files (the `.dartServer` folder).

If you know a better way, I'm all for it :-)